### PR TITLE
feat(seo): 添加SEO优化功能，包括元数据生成、多语言支持和robots/sitemap配置

### DIFF
--- a/app/[locale]/(main)/about/layout.tsx
+++ b/app/[locale]/(main)/about/layout.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+const aboutCopy = {
+  zh: {
+    title: "关于陆向谦实验室",
+    description: "了解陆向谦实验室的使命、办学理念、创始人经历与发展历程，探索创新教育的愿景。",
+  },
+  en: {
+    title: "About Lu Lab",
+    description: "Learn about Lu Lab's mission, teaching philosophy, founder story, and milestones behind the innovation-focused education lab.",
+  },
+};
+
+export async function generateMetadata({
+  params: { locale }
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  const copy = aboutCopy[locale as 'zh' | 'en'] ?? aboutCopy.zh;
+
+  return buildPageMetadata({
+    locale,
+    path: '/about',
+    title: copy.title,
+    description: copy.description,
+  });
+}
+
+export default function AboutLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/[locale]/(main)/bootcamp/layout.tsx
+++ b/app/[locale]/(main)/bootcamp/layout.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+const bootcampCopy = {
+  zh: {
+    title: "训练营项目",
+    description: "加入陆向谦实验室训练营，参与AI、编程与产品实战项目，获得导师辅导与团队协作体验。",
+  },
+  en: {
+    title: "Bootcamp Programs",
+    description: "Join Lu Lab bootcamps to work on AI, coding, and product projects with mentors, team practice, and industry-grade workflows.",
+  },
+};
+
+export async function generateMetadata({
+  params: { locale }
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  const copy = bootcampCopy[locale as 'zh' | 'en'] ?? bootcampCopy.zh;
+
+  return buildPageMetadata({
+    locale,
+    path: '/bootcamp',
+    title: copy.title,
+    description: copy.description,
+  });
+}
+
+export default function BootcampLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/[locale]/(main)/clubs/page.tsx
+++ b/app/[locale]/(main)/clubs/page.tsx
@@ -10,6 +10,34 @@
  */
 
 import React from 'react';
+import type { Metadata } from 'next';
+import { buildPageMetadata } from '@/lib/seo';
+
+const clubsCopy = {
+    zh: {
+        title: '俱乐部',
+        description: '探索陆向谦实验室的元宇宙与人工智能俱乐部，体验游戏化学习与团队项目实践。',
+    },
+    en: {
+        title: 'Clubs',
+        description: 'Discover Lu Lab clubs for metaverse and AI, combining gamified learning with collaborative projects.',
+    },
+};
+
+export async function generateMetadata({
+    params: { locale }
+}: {
+    params: { locale: string };
+}): Promise<Metadata> {
+    const copy = clubsCopy[locale as 'zh' | 'en'] ?? clubsCopy.zh;
+
+    return buildPageMetadata({
+        locale,
+        path: '/clubs',
+        title: copy.title,
+        description: copy.description,
+    });
+}
 
 interface Club {
     id: number;

--- a/app/[locale]/(main)/course/layout.tsx
+++ b/app/[locale]/(main)/course/layout.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+const courseCopy = {
+  zh: {
+    title: "课程精选",
+    description: "浏览并购买陆向谦实验室的精选课程，支持在线支付与多设备学习体验。",
+  },
+  en: {
+    title: "Featured Courses",
+    description: "Explore Lu Lab's featured courses and purchase online with a seamless, multi-device learning experience.",
+  },
+};
+
+export async function generateMetadata({
+  params: { locale }
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  const copy = courseCopy[locale as 'zh' | 'en'] ?? courseCopy.zh;
+
+  return buildPageMetadata({
+    locale,
+    path: '/course',
+    title: copy.title,
+    description: copy.description,
+  });
+}
+
+export default function CourseLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/[locale]/(navbar-only)/page.tsx
+++ b/app/[locale]/(navbar-only)/page.tsx
@@ -12,6 +12,34 @@
 
 import React from "react";
 import { Hero } from "@/components/sections/Hero";
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+const homeCopy = {
+  zh: {
+    title: "陆向谦实验室首页",
+    description: "陆向谦实验室以项目式学习与全球导师网络，帮助学员在真实项目中探索创新、创业与职业发展。",
+  },
+  en: {
+    title: "Lu Lab Home",
+    description: "Lu Lab blends project-based learning with a global mentor network to help students grow through real-world innovation and entrepreneurship projects.",
+  },
+};
+
+export async function generateMetadata({
+  params: { locale }
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  const copy = homeCopy[locale as 'zh' | 'en'] ?? homeCopy.zh;
+
+  return buildPageMetadata({
+    locale,
+    path: '/',
+    title: copy.title,
+    description: copy.description,
+  });
+}
 
 const Home: React.FC = () => {
 

--- a/app/[locale]/(no-chrome)/admin/layout.tsx
+++ b/app/[locale]/(no-chrome)/admin/layout.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+const adminCopy = {
+  zh: {
+    title: "管理后台",
+    description: "陆向谦实验室管理后台入口，仅供授权用户访问。",
+  },
+  en: {
+    title: "Admin Console",
+    description: "Lu Lab admin console for authorized users only.",
+  },
+};
+
+export async function generateMetadata({
+  params: { locale }
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  const copy = adminCopy[locale as 'zh' | 'en'] ?? adminCopy.zh;
+
+  return buildPageMetadata({
+    locale,
+    path: '/admin',
+    title: copy.title,
+    description: copy.description,
+    noIndex: true,
+  });
+}
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/[locale]/(no-chrome)/checkout/layout.tsx
+++ b/app/[locale]/(no-chrome)/checkout/layout.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+const checkoutCopy = {
+  zh: {
+    title: "结账",
+    description: "完成陆向谦实验室课程与训练营支付的安全结账页面。",
+  },
+  en: {
+    title: "Checkout",
+    description: "Secure checkout for Lu Lab courses and bootcamps.",
+  },
+};
+
+export async function generateMetadata({
+  params: { locale }
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  const copy = checkoutCopy[locale as 'zh' | 'en'] ?? checkoutCopy.zh;
+
+  return buildPageMetadata({
+    locale,
+    path: '/checkout',
+    title: copy.title,
+    description: copy.description,
+    noIndex: true,
+  });
+}
+
+export default function CheckoutLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/[locale]/(no-chrome)/login/layout.tsx
+++ b/app/[locale]/(no-chrome)/login/layout.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+const loginCopy = {
+  zh: {
+    title: "登录",
+    description: "登录陆向谦实验室账户，访问管理后台或个人学习进度。",
+  },
+  en: {
+    title: "Sign In",
+    description: "Sign in to your Lu Lab account to access the admin console or your learning progress.",
+  },
+};
+
+export async function generateMetadata({
+  params: { locale }
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  const copy = loginCopy[locale as 'zh' | 'en'] ?? loginCopy.zh;
+
+  return buildPageMetadata({
+    locale,
+    path: '/login',
+    title: copy.title,
+    description: copy.description,
+    noIndex: true,
+  });
+}
+
+export default function LoginLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/[locale]/(no-chrome)/return/layout.tsx
+++ b/app/[locale]/(no-chrome)/return/layout.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+const returnCopy = {
+  zh: {
+    title: "支付结果",
+    description: "查看陆向谦实验室课程或训练营的支付结果与返回信息。",
+  },
+  en: {
+    title: "Payment Status",
+    description: "Review your Lu Lab course or bootcamp payment status and return details.",
+  },
+};
+
+export async function generateMetadata({
+  params: { locale }
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  const copy = returnCopy[locale as 'zh' | 'en'] ?? returnCopy.zh;
+
+  return buildPageMetadata({
+    locale,
+    path: '/return',
+    title: copy.title,
+    description: copy.description,
+    noIndex: true,
+  });
+}
+
+export default function ReturnLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/[locale]/agreement.html/layout.tsx
+++ b/app/[locale]/agreement.html/layout.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+const agreementCopy = {
+  zh: {
+    title: "用户协议",
+    description: "查阅陆向谦实验室的用户协议与服务条款，了解课程、支付与隐私相关说明。",
+  },
+  en: {
+    title: "User Agreement",
+    description: "Review Lu Lab's user agreement and terms of service covering courses, payments, and privacy information.",
+  },
+};
+
+export async function generateMetadata({
+  params: { locale }
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  const copy = agreementCopy[locale as 'zh' | 'en'] ?? agreementCopy.zh;
+
+  return buildPageMetadata({
+    locale,
+    path: '/agreement.html',
+    title: copy.title,
+    description: copy.description,
+  });
+}
+
+export default function AgreementLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -12,13 +12,18 @@
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
 import React from 'react';
+import type { Metadata } from 'next';
 import "./globals.css";
 import { Toaster } from "@/components/ui/toaster"
+import { getBaseMetadata } from '@/lib/seo';
 
-export const metadata = {
-  title: 'Lu Lab',
-  description: 'Lu Lab Website',
-};
+export async function generateMetadata({
+  params: { locale }
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  return getBaseMetadata(locale);
+}
 
 export default async function RootLayout({
   children,
@@ -32,10 +37,6 @@ export default async function RootLayout({
 
   return (
     <html lang={locale}>
-      <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-      </head>
       <body>
         <NextIntlClientProvider messages={messages}>
           <div className="flex flex-col min-h-screen">

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,23 @@
+import { MetadataRoute } from 'next';
+import { routing } from '@/i18n/routing';
+import { getSiteUrl } from '@/lib/seo';
+
+const DISALLOW_PATHS = ['/api', '/admin', '/login', '/checkout', '/return'];
+
+export default function robots(): MetadataRoute.Robots {
+  const siteUrl = getSiteUrl().toString().replace(/\/$/, '');
+  const localizedDisallows = routing.locales.flatMap((locale) =>
+    DISALLOW_PATHS.map((path) => `/${locale}${path}`)
+  );
+
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        disallow: [...DISALLOW_PATHS, ...localizedDisallows],
+      },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,33 @@
+import { MetadataRoute } from 'next';
+import { routing } from '@/i18n/routing';
+import { getSiteUrl } from '@/lib/seo';
+
+const PUBLIC_PATHS = ['/', '/bootcamp', '/about', '/course', '/clubs', '/agreement.html'];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = getSiteUrl().toString().replace(/\/$/, '');
+  const lastModified = new Date();
+
+  const localizedEntries: MetadataRoute.Sitemap = routing.locales.flatMap((locale) =>
+    PUBLIC_PATHS.map((path) => {
+      const normalizedPath = path === '/' ? '' : path;
+
+      return {
+        url: `${baseUrl}/${locale}${normalizedPath}`,
+        lastModified,
+        changeFrequency: 'weekly',
+        priority: path === '/' ? 1 : 0.8,
+      };
+    })
+  );
+
+  return [
+    {
+      url: baseUrl,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    ...localizedEntries,
+  ];
+}

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,201 @@
+import { Metadata } from 'next';
+import { routing } from '@/i18n/routing';
+
+const DEFAULT_FALLBACK_SITE_URL = 'https://lulabs.org';
+const DEFAULT_OG_IMAGE = '/images/leadership.webp';
+
+const seoLocaleMap: Record<string, string> = {
+  en: 'en_US',
+  zh: 'zh_CN',
+};
+
+const siteCopy = {
+  name: 'Lu Lab',
+  slogans: {
+    en: 'Building a borderless Stanford-style lab',
+    zh: '打造没有围墙的网上斯坦福大学',
+  },
+  descriptions: {
+    en: 'Lu Lab is an innovation-focused education lab delivering project-based bootcamps, clubs, and mentorship to help students grow with a global mindset.',
+    zh: '陆向谦实验室专注创新教育，提供项目式训练营、俱乐部与导师辅导，帮助学员以全球视野成长。',
+  },
+  keywords: {
+    en: [
+      'Lu Lab',
+      'project-based learning',
+      'innovation education',
+      'bootcamp',
+      'entrepreneurship',
+      'STEM education',
+      'global mindset',
+    ],
+    zh: [
+      '陆向谦实验室',
+      'Lu Lab',
+      '创新教育',
+      '项目式学习',
+      '训练营',
+      '创业教育',
+      '科技教育',
+      '国际化视野',
+    ],
+  },
+};
+
+const getConfiguredSiteUrl = () => {
+  const envUrl =
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.NEXTAUTH_URL ||
+    DEFAULT_FALLBACK_SITE_URL;
+
+  try {
+    return new URL(envUrl);
+  } catch (error) {
+    console.warn('Invalid site URL provided, falling back to default', error);
+    return new URL(DEFAULT_FALLBACK_SITE_URL);
+  }
+};
+
+export const getSiteUrl = getConfiguredSiteUrl;
+
+const buildLanguageAlternates = (pathname: string) => {
+  const normalizedPath = pathname === '/' ? '' : pathname;
+
+  return routing.locales.reduce<Record<string, string>>((acc, locale) => {
+    acc[locale] = `/${locale}${normalizedPath}`;
+    return acc;
+  }, {});
+};
+
+const buildOgImageUrl = (imagePath: string) => {
+  const base = getConfiguredSiteUrl();
+  return new URL(imagePath, base).toString();
+};
+
+export const getBaseMetadata = (locale: string): Metadata => {
+  const metadataBase = getConfiguredSiteUrl();
+  const description = siteCopy.descriptions[locale as 'en' | 'zh'] ?? siteCopy.descriptions.zh;
+  const keywords = siteCopy.keywords[locale as 'en' | 'zh'] ?? siteCopy.keywords.zh;
+  const ogLocale = seoLocaleMap[locale] ?? seoLocaleMap.zh;
+  const alternateLocales = routing.locales.filter((value) => value !== locale).map((value) => seoLocaleMap[value] ?? value);
+  const ogImage = buildOgImageUrl(DEFAULT_OG_IMAGE);
+
+  return {
+    metadataBase,
+    applicationName: siteCopy.name,
+    title: {
+      default: `${siteCopy.name} | ${siteCopy.slogans[locale as 'en' | 'zh'] ?? siteCopy.slogans.zh}`,
+      template: `%s | ${siteCopy.name}`,
+    },
+    description,
+    keywords,
+    alternates: {
+      canonical: `/${locale}`,
+      languages: buildLanguageAlternates('/'),
+    },
+    openGraph: {
+      title: `${siteCopy.name} | ${siteCopy.slogans[locale as 'en' | 'zh'] ?? siteCopy.slogans.zh}`,
+      description,
+      url: `/${locale}`,
+      siteName: siteCopy.name,
+      locale: ogLocale,
+      alternateLocale: alternateLocales,
+      images: [
+        {
+          url: ogImage,
+          width: 1200,
+          height: 630,
+          alt: `${siteCopy.name} hero image`,
+        },
+      ],
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${siteCopy.name} | ${siteCopy.slogans[locale as 'en' | 'zh'] ?? siteCopy.slogans.zh}`,
+      description,
+      images: [ogImage],
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+    creator: siteCopy.name,
+    publisher: siteCopy.name,
+    formatDetection: {
+      email: false,
+      address: false,
+      telephone: false,
+    },
+  };
+};
+
+export const buildPageMetadata = ({
+  locale,
+  path = '/',
+  title,
+  description,
+  keywords,
+  image = DEFAULT_OG_IMAGE,
+  noIndex = false,
+}: {
+  locale: string;
+  path?: string;
+  title: string;
+  description: string;
+  keywords?: string[];
+  image?: string;
+  noIndex?: boolean;
+}): Metadata => {
+  const metadataBase = getConfiguredSiteUrl();
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const localizedPath = `/${locale}${normalizedPath === '/' ? '' : normalizedPath}`;
+  const ogLocale = seoLocaleMap[locale] ?? seoLocaleMap.zh;
+  const alternateLocales = routing.locales.filter((value) => value !== locale).map((value) => seoLocaleMap[value] ?? value);
+  const ogImage = buildOgImageUrl(image);
+
+  return {
+    metadataBase,
+    title,
+    description,
+    keywords: keywords ?? siteCopy.keywords[locale as 'en' | 'zh'] ?? siteCopy.keywords.zh,
+    alternates: {
+      canonical: localizedPath,
+      languages: buildLanguageAlternates(normalizedPath),
+    },
+    openGraph: {
+      title,
+      description,
+      url: localizedPath,
+      siteName: siteCopy.name,
+      locale: ogLocale,
+      alternateLocale: alternateLocales,
+      images: [
+        {
+          url: ogImage,
+          width: 1200,
+          height: 630,
+          alt: `${title} | ${siteCopy.name}`,
+        },
+      ],
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [ogImage],
+    },
+    robots: {
+      index: !noIndex,
+      follow: !noIndex,
+    },
+  };
+};
+
+export const seoDefaults = {
+  siteCopy,
+  seoLocaleMap,
+  DEFAULT_OG_IMAGE,
+  DEFAULT_FALLBACK_SITE_URL,
+};


### PR DESCRIPTION
- 新增lib/seo.ts提供基础元数据和页面特定元数据生成功能
- 为所有页面添加多语言支持的元数据配置
- 实现robots.txt和sitemap.xml动态生成
- 为敏感路径(如/admin, /login)添加noIndex标记
- 统一管理多语言文案和SEO相关配置